### PR TITLE
Making possible the start Liquid as an application dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # Liquid
 
-It's a templating library for Elixir.  
-Continuation of the fluid liquid conversion. 
+It's a templating library for Elixir.
+Continuation of the fluid liquid conversion.
 
 ## Usage
-Add the dependency to your mix file
 
-Start the application:
+Add the dependency to your mix file:
+
+``` elixir
+# mix.exs
+defp deps do
+  […,
+   {:liquid, "~> 0.1.0"}]
+end
+```
+
+You can either start the application directly:
 
 `Liquid.start`
+
+Or start it with your application:
+
+``` elixir
+# mix.exs
+def application do
+  [mod: {MyApp, []},
+   applications: […, :liquid]]
+end
+```
 
 Compile a template from a string:
 
@@ -16,7 +35,7 @@ Compile a template from a string:
 
 Render the template with a keyword list representing the local variables:
 
-`{ :ok, rendered } = Liquid.Template.render(template, [world: "world"])`
+`{ :ok, rendered, _ } = Liquid.Template.render(template, [world: "world"])`
 
 The tests should give a pretty good idea of the features implemented so far.
 

--- a/lib/liquid.ex
+++ b/lib/liquid.ex
@@ -1,4 +1,8 @@
 defmodule Liquid do
+  use Application
+
+  def start(_type, _args), do: start
+
   def start do
     Liquid.Registers.start
     Liquid.FileSystem.start

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Liquid.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    []
+    [mod: {Liquid, []}]
   end
 
   # Returns the list of dependencies in the format:


### PR DESCRIPTION
This sets up what's needed for Liquid to be able to be started as an application dependency.

In short:

* using `Application` in the `Liquid` module
* defining `Liquid.start/2` to comply with the arguments Mix provides
* setting the `Liquid` module as the one to start in `mix.exs`

_Sidenote: I also updated the examples in the REAMDE to reflect the returned value of `Liquid.Template.render/2`_

Your comments are very welcome, it's my first PR on an Elixir project :grin: